### PR TITLE
Fj 2024 lesson 9

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,8 @@ dependencies {
     implementation("org.slf4j:slf4j-api:2.0.16")
     implementation("io.github.oshai:kotlin-logging:7.0.0")
 
+    implementation("com.typesafe:config:1.4.3")
+
     testImplementation(kotlin("test"))
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     kotlin("jvm") version "2.0.10"
     id("org.jetbrains.kotlin.plugin.serialization") version "2.0.20"
+    id("jacoco")
 }
 
 group = "org.example"
@@ -11,8 +12,8 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-serialization-kotlinx-json:3.0.0-rc-1")
-    implementation("io.ktor:ktor-client-content-negotiation:3.0.0-rc-1")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:3.0.0")
+    implementation("io.ktor:ktor-client-content-negotiation:3.0.0")
     implementation("io.ktor:ktor-client-cio:3.0.0-rc-1")
 
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")
@@ -23,12 +24,27 @@ dependencies {
 
     implementation("com.typesafe:config:1.4.3")
 
-    testImplementation(kotlin("test"))
+    testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
+    testImplementation("io.kotest:kotest-assertions-core:5.9.1")
+    testImplementation("io.mockk:mockk:1.13.13")
+    testImplementation("io.ktor:ktor-client-mock:3.0.0")
+    testImplementation("io.ktor:ktor-client-content-negotiation:3.0.0")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
 }
 
-tasks.test {
+tasks.withType<Test>().configureEach {
     useJUnitPlatform()
+    finalizedBy(tasks.jacocoTestReport)
 }
+
+tasks.jacocoTestReport {
+    reports {
+        xml.required = false
+        csv.required = false
+        html.outputLocation = layout.buildDirectory.dir("jacocoHtml")
+    }
+}
+
 kotlin {
     jvmToolchain(21)
 }

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,5 +1,6 @@
 package org.example
 
+import com.typesafe.config.ConfigFactory
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.*
 import io.ktor.client.engine.cio.CIO
@@ -11,25 +12,41 @@ import org.example.client.KudaGoCoroutineFlow
 import org.example.dto.News
 import org.example.util.NewsPrinter
 import org.example.util.file.NewsFileManagerImpl
+import java.io.File
 import kotlin.system.measureTimeMillis
 
 private val logger = KotlinLogging.logger {}
 
+class AppConfig(configFile: String = "src/main/resources/application.conf") {
+
+    private val config = ConfigFactory.parseFile(File(configFile)).resolve()
+
+    val totalNewsCount: Int = config.getInt("app.totalNewsCount")
+    val workerCount: Int = config.getInt("app.workerCount")
+    val maxConcurrentRequests: Int = config.getInt("app.maxConcurrentRequests")
+    val maxPageSize: Int = config.getInt("app.maxPageSize")
+    val maxRetries: Int = config.getInt("app.maxRetries")
+    val retryDelay: Long = config.getLong("app.retryDelay")
+    val baseUrl: String = config.getString("app.baseUrl")
+}
+
+
 suspend fun main() {
+    val config = AppConfig()
     val client = HttpClient(CIO) {
         install(ContentNegotiation) {
             json()
         }
     }
 
-    val totalNewsCount = 10_000
-    val workerCount = 3
-
-    val kudaGoClient = KudaGoClientImpl(client)
     val newsFileManager = NewsFileManagerImpl()
+    val kudaGoClient = KudaGoClientImpl(
+        client, config.baseUrl, config.maxPageSize,
+        config.maxRetries, config.retryDelay, config.maxConcurrentRequests
+    )
 
     logger.info { "Downloading news from API..." }
-    val newsList = kudaGoClient.getAllNews(totalNewsCount)
+    val newsList = kudaGoClient.getAllNews(config.totalNewsCount)
     val period = LocalDate(2023, 10, 31)..LocalDate(2024, 10, 31)
     logger.info { "Filtering downloaded news..." }
     val filteredNews = newsList.getMostRatedNews(10, period)
@@ -38,18 +55,20 @@ suspend fun main() {
 
     printNews(filteredNews)
 
-    val flow = KudaGoCoroutineFlow(kudaGoClient, totalNewsCount, workerCount)
+    val flow = KudaGoCoroutineFlow(
+        kudaGoClient, config.totalNewsCount,
+        config.workerCount, config.maxPageSize
+    )
 
     val time = measureTimeMillis {
         flow.execute()
     }
 
-    println("Execution completed in $time ms")
+    logger.info { "Execution completed in $time ms" }
 }
 
 fun List<News>.getMostRatedNews(
-    count: Int,
-    period: ClosedRange<LocalDate>
+    count: Int, period: ClosedRange<LocalDate>
 ): List<News> {
     return this.filter { news ->
         news.publicationDate.date in period

--- a/src/main/kotlin/client/KudaGoClient.kt
+++ b/src/main/kotlin/client/KudaGoClient.kt
@@ -4,5 +4,5 @@ import org.example.dto.News
 
 interface KudaGoClient {
 
-    fun getNews(count: Int = 100): List<News>
+    fun getAllNews(count: Int = 100): List<News>
 }

--- a/src/main/kotlin/client/KudaGoClientImpl.kt
+++ b/src/main/kotlin/client/KudaGoClientImpl.kt
@@ -17,15 +17,25 @@ class KudaGoClientImpl(
 ) : KudaGoClient {
 
     companion object {
-        private const val BASE_URL = "https://kudago.com/public-api/v1.4/news/"
-        private const val MAX_PAGE_SIZE = 100
-        private const val MAX_RETRIES = 3
-        private const val RETRY_DELAY_MS = 1000L
+        const val BASE_URL = "https://kudago.com/public-api/v1.4/news/"
+        const val MAX_PAGE_SIZE = 100
+        const val MAX_RETRIES = 3
+        const val RETRY_DELAY_MS = 1000L
     }
 
     private val logger = KotlinLogging.logger {}
 
-    override fun getNews(count: Int): List<News> {
+    suspend fun getNewsPage(page: Int, pageSize: Int): List<News> {
+        return try {
+            val response = retryRequest(page, pageSize)
+            response.results
+        } catch (e: Exception) {
+            logger.error { "Failed to fetch news: ${e.message}" }
+            emptyList()
+        }
+    }
+
+    override fun getAllNews(count: Int): List<News> {
         return runBlocking {
             try {
                 val newsList = mutableListOf<News>()

--- a/src/main/kotlin/client/KudaGoClientImpl.kt
+++ b/src/main/kotlin/client/KudaGoClientImpl.kt
@@ -6,32 +6,35 @@ import io.ktor.client.call.body
 import io.ktor.client.request.*
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.HttpStatusCode
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import org.example.dto.News
 import org.example.dto.NewsResponse
 
 
 class KudaGoClientImpl(
     private val client: HttpClient,
+    val baseUrl: String,
+    val maxPageSize: Int = 100,
+    val maxRetries: Int = 3,
+    val retryDelay: Long = 1000L,
+    maxConcurrentRequests: Int = 5
 ) : KudaGoClient {
 
-    companion object {
-        const val BASE_URL = "https://kudago.com/public-api/v1.4/news/"
-        const val MAX_PAGE_SIZE = 100
-        const val MAX_RETRIES = 3
-        const val RETRY_DELAY_MS = 1000L
-    }
-
     private val logger = KotlinLogging.logger {}
+    private val semaphore = Semaphore(maxConcurrentRequests)
 
     suspend fun getNewsPage(page: Int, pageSize: Int): List<News> {
-        return try {
-            val response = retryRequest(page, pageSize)
-            response.results
-        } catch (e: Exception) {
-            logger.error { "Failed to fetch news: ${e.message}" }
-            emptyList()
+        return semaphore.withPermit {
+            try {
+                val response = retryRequest(page, pageSize)
+                response.results
+            } catch (e: Exception) {
+                logger.error { "Failed to fetch news: ${e.message}" }
+                emptyList()
+            }
         }
     }
 
@@ -39,13 +42,13 @@ class KudaGoClientImpl(
         return runBlocking {
             try {
                 val newsList = mutableListOf<News>()
-                val totalPages = (count + MAX_PAGE_SIZE - 1) / MAX_PAGE_SIZE
+                val totalPages = (count + maxPageSize - 1) / maxPageSize
 
                 for (page in 1..totalPages) {
                     val currentPageSize = if (page == totalPages) {
                         count - newsList.size
                     } else {
-                        MAX_PAGE_SIZE
+                        maxPageSize
                     }
 
                     val newsResponse = retryRequest(page, currentPageSize)
@@ -62,14 +65,17 @@ class KudaGoClientImpl(
     }
 
     private suspend fun retryRequest(page: Int, pageSize: Int): NewsResponse {
-        repeat(MAX_RETRIES) { attempt ->
+        repeat(maxRetries) { attempt ->
             try {
                 logger.debug { "Getting page with number '$page' and size '$pageSize' (Attempt ${attempt + 1})..." }
-                val response: HttpResponse = client.get(BASE_URL) {
+                val response: HttpResponse = client.get(baseUrl) {
                     parameter("location", "msk")
                     parameter("text_format", "text")
                     parameter("expand", "place")
-                    parameter("fields", "id,title,place,description,site_url,favorites_count,comments_count,publication_date")
+                    parameter(
+                        "fields",
+                        "id,title,place,description,site_url,favorites_count,comments_count,publication_date"
+                    )
                     parameter("page_size", pageSize)
                     parameter("page", page)
                 }
@@ -82,8 +88,8 @@ class KudaGoClientImpl(
                 }
             } catch (e: Exception) {
                 logger.error { "Error on attempt ${attempt + 1}: ${e.message}" }
-                if (attempt == MAX_RETRIES - 1) throw e
-                delay(RETRY_DELAY_MS)
+                if (attempt == maxPageSize - 1) throw e
+                delay(retryDelay)
             }
         }
         throw Exception("Max retries number reached! Check your internet connection")

--- a/src/main/kotlin/client/KudaGoCoroutineFlow.kt
+++ b/src/main/kotlin/client/KudaGoCoroutineFlow.kt
@@ -1,0 +1,60 @@
+package org.example.client
+
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.newFixedThreadPoolContext
+import org.example.dto.News
+import org.example.util.NewsPrinter
+import java.io.File
+import kotlin.math.ceil
+
+class KudaGoCoroutineFlow(
+    private val kudaGoClient: KudaGoClientImpl,
+    private val totalNewsCount: Int,
+    private val workerCount: Int
+) {
+
+    private val channel = Channel<News>(Channel.UNLIMITED)
+    @OptIn(DelicateCoroutinesApi::class)
+    private val threadPool = newFixedThreadPoolContext(workerCount, "WorkerPool")
+    private val printer = NewsPrinter()
+
+    suspend fun execute() = coroutineScope {
+        val workerJobs = List(workerCount) { workerId ->
+            launch(threadPool) {
+                worker(workerId)
+            }
+        }
+
+        val processorJob = launch { processor() }
+
+        workerJobs.joinAll()
+        channel.close()
+        processorJob.join()
+    }
+
+    private suspend fun worker(id: Int) {
+        val totalPages = ceil(totalNewsCount.toDouble() / KudaGoClientImpl.MAX_PAGE_SIZE).toInt()
+        var currentPage = id
+
+        while (currentPage < totalPages) {
+            val news = kudaGoClient.getNewsPage(currentPage + 1, KudaGoClientImpl.MAX_PAGE_SIZE)
+            news.forEach { channel.send(it) }
+            currentPage += workerCount
+        }
+    }
+
+    private suspend fun processor() {
+        File("news_output.md").bufferedWriter().use { writer ->
+            for (news in channel) {
+                printer.formatNews(news)
+                writer.write(printer.build())
+                writer.newLine()
+                printer.clear()
+            }
+        }
+    }
+}

--- a/src/main/kotlin/util/NewsPrinter.kt
+++ b/src/main/kotlin/util/NewsPrinter.kt
@@ -1,26 +1,53 @@
 package org.example.util
 
+import org.example.dto.News
+
 class NewsPrinter {
     private val stringBuilder = StringBuilder()
 
-    fun header(level: Int, content: () -> String) {
+    private fun header(level: Int, content: () -> String) {
         stringBuilder.append("#".repeat(level)).append(" ")
         stringBuilder.append(content()).append("\n\n")
     }
 
-    fun text(content: () -> String) {
+    private fun text(content: () -> String) {
         stringBuilder.append(content()).append("\n")
     }
 
-    fun bold(content: String) = "**$content**"
+    private fun bold(content: String) = "**$content**"
 
-    fun underlined(content: String) = "__${content}__"
+    private fun underlined(content: String) = "__${content}__"
 
-    fun link(url: String, text: String) = "[$text]($url)"
+    private fun link(url: String, text: String) = "[$text]($url)"
 
-    fun divider() {
+    private fun divider() {
         stringBuilder.append("\n---\n\n")
     }
 
     fun build() = stringBuilder.toString()
+
+    fun clear() {
+        stringBuilder.clear()
+    }
+
+    fun formatNews(news: News) {
+        with(this) {
+            header(1) { bold(news.title) }
+
+            text { "Дата публикации: ${news.publicationDate}" }
+            text { "Местоположение: ${underlined(news.place)}" }
+
+            header(2) { "Описание" }
+            text { news.description }
+
+            header(2) { "Статистика" }
+            text { "Закладки: ${news.favoritesCount}" }
+            text { "Комментарии: ${news.commentsCount}" }
+            text { "Рейтинг: ${String.format("%.2f", news.rating)}" }
+
+            text { "Читать в источнике: ${link(news.siteUrl, "ссылка")}" }
+
+            divider()
+        }
+    }
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,0 +1,10 @@
+app {
+  totalNewsCount = 10000
+  workerCount = 20
+  maxConcurrentRequests = 5
+  maxPageSize = 100
+  maxRetries = 3
+  retryDelay = 1000
+  baseUrl = "https://kudago.com/public-api/v1.4/news/"
+}
+

--- a/src/test/kotlin/client/KudaGoClientImplTest.kt
+++ b/src/test/kotlin/client/KudaGoClientImplTest.kt
@@ -1,0 +1,188 @@
+package client
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.*
+import io.ktor.client.engine.mock.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.example.client.KudaGoClientImpl
+import org.example.dto.News
+import org.example.dto.NewsResponse
+
+class KudaGoClientImplTest : StringSpec({
+
+    "getNewsPage should return list of News on successful response" {
+        val mockEngine = MockEngine { request ->
+            respond(
+                content = Json.encodeToString(
+                    NewsResponse(
+                        count = 10,
+                        next = "",
+                        previous = "",
+                        results = listOf(
+                            News(1, "News 1", "place 1", "description 1", "https://example.com/1", 1, 1,
+                                Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())),
+                            News(2, "News 2", "place 2", "description 2", "https://example.com/2", 2, 2,
+                                Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()))
+                        )
+                    )
+                ),
+                status = HttpStatusCode.OK,
+                headers = headersOf("Content-Type" to listOf(ContentType.Application.Json.toString()))
+            )
+        }
+
+        val client = HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json()
+            }
+        }
+
+        val kudaGoClient = KudaGoClientImpl(
+            client = client,
+            baseUrl = "https://example.com",
+            maxRetries = 3,
+            retryDelay = 100L
+        )
+
+        val result = runBlocking { kudaGoClient.getNewsPage(page = 1, pageSize = 2) }
+
+        result.size shouldBe 2
+        result[0].id shouldBe 1
+        result[0].title shouldBe "News 1"
+        result[1].id shouldBe 2
+        result[1].title shouldBe "News 2"
+    }
+
+    "getNewsPage should return empty list after max retries on failure" {
+        val mockEngine = MockEngine { request ->
+            respondError(HttpStatusCode.InternalServerError)
+        }
+
+        val client = HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json()
+            }
+        }
+
+        val kudaGoClient = KudaGoClientImpl(
+            client = client,
+            baseUrl = "https://example.com",
+            maxRetries = 3,
+            retryDelay = 10L
+        )
+
+        val result = runBlocking { kudaGoClient.getNewsPage(page = 1, pageSize = 2) }
+
+        result shouldBe emptyList()
+    }
+
+    "getAllNews should return combined list of News across multiple pages" {
+        val totalNews = 5
+        val pageSize = 2
+
+        val mockEngine = MockEngine { request ->
+            val page = request.url.parameters["page"]?.toIntOrNull() ?: 1
+            val newsList = when (page) {
+                1 -> listOf(
+                    News(1, "News 1", "place 1", "description 1", "https://example.com/1", 1, 1,
+                        Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())),
+                    News(2, "News 2", "place 2", "description 2", "https://example.com/2", 1, 1,
+                        Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()))
+                )
+                2 -> listOf(
+                    News(3, "News 3", "place 3", "description 3", "https://example.com/3", 1, 1,
+                        Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())),
+                    News(4, "News 4", "place 4", "description 4", "https://example.com/4", 1, 1,
+                        Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()))
+                )
+                3 -> listOf(
+                    News(5, "News 5", "place 5", "description 5", "https://example.com/5", 1, 1,
+                        Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()))
+                )
+                else -> emptyList()
+            }
+            respond(
+                content = Json.encodeToString(NewsResponse(
+                    count = 10,
+                    next = "",
+                    previous = "",
+                    results = newsList
+                )),
+                status = HttpStatusCode.OK,
+                headers = headersOf("Content-Type" to listOf(ContentType.Application.Json.toString()))
+            )
+        }
+
+        val client = HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json()
+            }
+        }
+
+        val kudaGoClient = KudaGoClientImpl(
+            client = client,
+            baseUrl = "https://example.com",
+            maxRetries = 3,
+            retryDelay = 10L,
+            maxPageSize = pageSize
+        )
+
+        val result = kudaGoClient.getAllNews(count = totalNews)
+
+        result.size shouldBe totalNews
+        result.map { it.id } shouldBe listOf(1, 2, 3, 4, 5)
+    }
+
+    "retryRequest should retry on failure and succeed on subsequent attempt" {
+        var attempt = 0
+        val mockEngine = MockEngine { request ->
+            attempt++
+            if (attempt < 2) {
+                respondError(HttpStatusCode.InternalServerError)
+            } else {
+                respond(
+                    content = Json.encodeToString(
+                        NewsResponse(
+                            count = 10,
+                            next = "",
+                            previous = "",
+                            results = listOf(
+                                News(1, "News 1", "place 1", "description 1", "https://example.com/1", 1, 1,
+                                    Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()))
+                            )
+                        )
+                    ),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf("Content-Type" to listOf(ContentType.Application.Json.toString()))
+                )
+            }
+        }
+
+        val client = HttpClient(mockEngine) {
+            install(ContentNegotiation) {
+                json()
+            }
+        }
+
+        val kudaGoClient = KudaGoClientImpl(
+            client = client,
+            baseUrl = "https://example.com",
+            maxRetries = 3,
+            retryDelay = 10L
+        )
+
+        val result = runBlocking { kudaGoClient.getNewsPage(page = 1, pageSize = 1) }
+
+        result.size shouldBe 1
+        result[0].id shouldBe 1
+    }
+})

--- a/src/test/kotlin/client/KudaGoCoroutineFlowTest.kt
+++ b/src/test/kotlin/client/KudaGoCoroutineFlowTest.kt
@@ -1,0 +1,149 @@
+package client
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.*
+import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import org.example.client.KudaGoClientImpl
+import org.example.client.KudaGoCoroutineFlow
+import org.example.dto.News
+import java.io.File
+
+class KudaGoCoroutineFlowTest : StringSpec({
+
+    beforeTest {
+        val newsFile = File("news.md")
+        if (newsFile.exists()) {
+            newsFile.delete()
+        }
+    }
+
+    "execute should successfully retrieve all news and write them to a file" {
+        val mockClient = mockk<KudaGoClientImpl>()
+
+        val totalNewsCount = 5
+        val workerCount = 2
+        val maxPageSize = 2
+
+        coEvery { mockClient.getNewsPage(1, 2) } returns listOf(
+            News(
+                1, "News 1", "place 1", "description 1", "https://example.com/1", 1, 1,
+                Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+            ),
+            News(
+                2, "News 2", "place 2", "description 2", "https://example.com/2", 1, 1,
+                Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+            )
+        )
+        coEvery { mockClient.getNewsPage(2, 2) } returns listOf(
+            News(
+                3, "News 3", "place 3", "description 3", "https://example.com/3", 1, 1,
+                Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+            ),
+            News(
+                4, "News 4", "place 4", "description 4", "https://example.com/4", 1, 1,
+                Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+            )
+        )
+        coEvery { mockClient.getNewsPage(3, 2) } returns listOf(
+            News(
+                5, "News 5", "place 5", "description 5", "https://example.com/5", 1, 1,
+                Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+            )
+        )
+
+        val flow = KudaGoCoroutineFlow(
+            kudaGoClient = mockClient,
+            totalNewsCount = totalNewsCount,
+            workerCount = workerCount,
+            maxPageSize = maxPageSize
+        )
+
+        runBlocking {
+            flow.execute()
+        }
+
+        val newsFile = File("news.md")
+        newsFile.exists() shouldBe true
+
+        coVerify(exactly = 1) { mockClient.getNewsPage(1, 2) }
+        coVerify(exactly = 1) { mockClient.getNewsPage(2, 2) }
+        coVerify(exactly = 1) { mockClient.getNewsPage(3, 2) }
+
+        confirmVerified(mockClient)
+    }
+
+    "execute should correctly handle the case when there are no news" {
+        val mockClient = mockk<KudaGoClientImpl>()
+
+        val totalNewsCount = 0
+        val workerCount = 2
+        val maxPageSize = 2
+
+        val flow = KudaGoCoroutineFlow(
+            kudaGoClient = mockClient,
+            totalNewsCount = totalNewsCount,
+            workerCount = workerCount,
+            maxPageSize = maxPageSize
+        )
+
+        runBlocking {
+            flow.execute()
+        }
+
+        val newsFile = File("news.md")
+        if (newsFile.exists()) {
+            val actualLines = newsFile.readLines()
+            actualLines shouldBe emptyList()
+            newsFile.delete()
+        } else {
+            true shouldBe true
+        }
+
+        coVerify(exactly = 0) { mockClient.getNewsPage(any(), any()) }
+        confirmVerified(mockClient)
+    }
+
+    "execute should correctly handle errors when retrieving pages" {
+        val mockClient = mockk<KudaGoClientImpl>()
+
+        val totalNewsCount = 3
+        val workerCount = 1
+        val maxPageSize = 2
+
+        coEvery { mockClient.getNewsPage(1, 2) } returns listOf(
+            News(
+                1, "News 1", "place 1", "description 1", "https://example.com/1", 1, 1,
+                Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+            ),
+            News(
+                2, "News 2", "place 2", "description 2", "https://example.com/2", 1, 1,
+                Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+            )
+        )
+
+        coEvery { mockClient.getNewsPage(2, 2) } returns emptyList()
+
+        val flow = KudaGoCoroutineFlow(
+            kudaGoClient = mockClient,
+            totalNewsCount = totalNewsCount,
+            workerCount = workerCount,
+            maxPageSize = maxPageSize
+        )
+
+        runBlocking {
+            flow.execute()
+        }
+
+        val newsFile = File("news.md")
+        newsFile.exists() shouldBe true
+
+        coVerify(exactly = 1) { mockClient.getNewsPage(1, 2) }
+        coVerify(exactly = 1) { mockClient.getNewsPage(2, 2) }
+
+        confirmVerified(mockClient)
+    }
+})


### PR DESCRIPTION
Покрыл тестами на Kotest

Результаты замеров скорости следующие:
| Количество потоков | 1       | 5       |
|--------------------|---------|---------|
| Время выполнения   | 37 сек. | 33 сек. |

Разница в количестве потоков в 5 раз, однако время уменьшилось лишь на 11%. Это говорит о том, что KudaGo использует механизм для блокировки множественных запросов от одного клиента. Например, `RateLimiter`